### PR TITLE
docker-compose version for those who really don't have time!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+redis-data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:14.11.0-buster-slim
+
+RUN apt-get update && apt-get install -y apache2-utils
+
+WORKDIR /app
+COPY package.json .
+
+# Installs both dev and production dependencies
+RUN yarn install
+
+COPY index.js .
+COPY __tests__ .
+
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # Rate Limiting Express w/ a Redis store
 
+* Initial Blog post at https://medium.com/@dennisokeeffe/the-abcs-of-rate-limiting-expressjs-servers-with-docker-redis-e196aaef82c7
+* Executing the `docker-compose` version you can navigate through the data using the Redis UI.
+
+<img width="578" alt="Screen Shot 2020-09-29 at 2 15 23 AM" src="https://user-images.githubusercontent.com/131457/94517659-c7c79980-01fe-11eb-8282-3c79cecd321b.png">
+
+* You can view the current state of Redis either by inspecting the aof file under `./redis-data`
+* You can also view the current state at the Redis UI at http://localhost:8080
+
 # Resources
 
+0. [redis-rate-limit-best-practices](https://redislabs.com/redis-best-practices/basic-rate-limiting/)
 1. [rate-limit-redis](https://github.com/wyattjoh/rate-limit-redis)
 2. [express-rate-limit](https://github.com/nfriedly/express-rate-limit)
 3. [Redis commands](https://redis.io/commands)
@@ -36,7 +45,7 @@ If limited, expects `Too many requests, please try again later.`.
 
 if successful, expects `RESPONSE_SUCCESS`.
 
-## Dockerized verison
+## docker-compose verison
 
 * Run the following container to get all at once...
 
@@ -144,8 +153,3 @@ tester_1    | Time:        1.569 s
 tester_1    | Ran all test suites.
 tester_1    | Done in 2.34s.
 ```
-
-* You can view the current state of Redis either by inspecting the aof file under `./redis-data`
-* You can also view the current state at the Redis UI at http://localhost:8080
-
-<img width="578" alt="Screen Shot 2020-09-29 at 2 15 23 AM" src="https://user-images.githubusercontent.com/131457/94517659-c7c79980-01fe-11eb-8282-3c79cecd321b.png">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rate Limiting Express w/ a Redis store
 
-## Resources
+# Resources
 
 1. [rate-limit-redis](https://github.com/wyattjoh/rate-limit-redis)
 2. [express-rate-limit](https://github.com/nfriedly/express-rate-limit)
@@ -35,3 +35,117 @@ yarn test
 If limited, expects `Too many requests, please try again later.`.
 
 if successful, expects `RESPONSE_SUCCESS`.
+
+## Dockerized verison
+
+* Run the following container to get all at once...
+
+```
+$ docker-compose up --build
+Building server
+Step 1/8 : FROM node:14.11.0-buster-slim
+ ---> bae31031f98e
+Step 2/8 : RUN apt-get update && apt-get install -y apache2-utils
+ ---> Using cache
+ ---> 411395e231b3
+Step 3/8 : WORKDIR /app
+ ---> Using cache
+ ---> cffce3bd5aaf
+Step 4/8 : COPY package.json .
+ ---> Using cache
+ ---> c09bfdf87871
+Step 5/8 : RUN yarn install
+ ---> Using cache
+ ---> a7c082ca68c2
+Step 6/8 : COPY index.js .
+ ---> Using cache
+ ---> 666473275621
+Step 7/8 : COPY __tests__ .
+ ---> Using cache
+ ---> 8986db312489
+Step 8/8 : CMD ["yarn", "start"]
+ ---> Using cache
+ ---> e626abe69316
+
+Successfully built e626abe69316
+Successfully tagged marcellodesales/rate-limiting-server-redis-client:latest
+Building tester
+Step 1/8 : FROM node:14.11.0-buster-slim
+ ---> bae31031f98e
+Step 2/8 : RUN apt-get update && apt-get install -y apache2-utils
+ ---> Using cache
+ ---> 411395e231b3
+Step 3/8 : WORKDIR /app
+ ---> Using cache
+ ---> cffce3bd5aaf
+Step 4/8 : COPY package.json .
+ ---> Using cache
+ ---> c09bfdf87871
+Step 5/8 : RUN yarn install
+ ---> Using cache
+ ---> a7c082ca68c2
+Step 6/8 : COPY index.js .
+ ---> Using cache
+ ---> 666473275621
+Step 7/8 : COPY __tests__ .
+ ---> Using cache
+ ---> 8986db312489
+Step 8/8 : CMD ["yarn", "start"]
+ ---> Using cache
+ ---> e626abe69316
+
+Successfully built e626abe69316
+Successfully tagged marcellodesales/rate-limiting-server-redis-client:latest
+Starting express-redis-rate-limiting_server_1   ... done
+Starting express-redis-rate-limiting_redis_1    ... done
+Starting express-redis-rate-limiting_tester_1   ... done
+Creating express-redis-rate-limiting_redis_ui_1 ... done
+Attaching to express-redis-rate-limiting_server_1, express-redis-rate-limiting_redis_1, express-redis-rate-limiting_tester_1, express-redis-rate-limiting_redis_ui_1
+redis_1     | 1:C 29 Sep 2020 05:08:49.917 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+redis_1     | 1:C 29 Sep 2020 05:08:49.917 # Redis version=6.0.8, bits=64, commit=00000000, modified=0, pid=1, just started
+redis_1     | 1:C 29 Sep 2020 05:08:49.917 # Configuration loaded
+redis_1     | 1:M 29 Sep 2020 05:08:49.918 * Running mode=standalone, port=6379.
+redis_1     | 1:M 29 Sep 2020 05:08:49.918 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
+redis_1     | 1:M 29 Sep 2020 05:08:49.918 # Server initialized
+redis_ui_1  | PHP 7.3.8 Development Server started at Tue Sep 29 05:08:49 2020
+tester_1    | wait-for-it.sh: waiting 15 seconds for server:8000
+redis_1     | 1:M 29 Sep 2020 05:08:49.993 * DB loaded from append only file: 0.074 seconds
+redis_1     | 1:M 29 Sep 2020 05:08:49.993 * Ready to accept connections
+server_1    | yarn run v1.22.5
+server_1    | $ node index.js
+server_1    | Server started
+tester_1    | wait-for-it.sh: server:8000 is available after 1 seconds
+tester_1    | yarn run v1.22.5
+tester_1    | $ jest
+tester_1    | PASS ./index.test.js
+tester_1    |   rate limiter server
+tester_1    |     ✓ expects GET / to return "Success" (269 ms)
+tester_1    |     ✓ expects rate limit response after too many requests (16 ms)
+tester_1    |
+tester_1    | Test Suites: 1 passed, 1 total
+tester_1    | Tests:       2 passed, 2 total
+tester_1    | Snapshots:   0 total
+tester_1    | Time:        1.559 s
+tester_1    | Ran all test suites.
+tester_1    | Done in 2.33s.
+tester_1    | wait-for-it.sh: waiting 15 seconds for server:8000
+tester_1    | wait-for-it.sh: server:8000 is available after 0 seconds
+tester_1    | yarn run v1.22.5
+tester_1    | $ jest
+tester_1    | PASS ./index.test.js
+tester_1    |   rate limiter server
+tester_1    |     ✓ expects GET / to return "Success" (227 ms)
+tester_1    |     ✓ expects rate limit response after too many requests (17 ms)
+tester_1    |
+tester_1    | Test Suites: 1 passed, 1 total
+tester_1    | Tests:       2 passed, 2 total
+tester_1    | Snapshots:   0 total
+tester_1    | Time:        1.569 s
+tester_1    | Ran all test suites.
+tester_1    | Done in 2.34s.
+```
+
+* You can view the current state of Redis either by inspecting the aof file under `./redis-data`
+* You can also view the current state at the Redis UI at http://localhost:8080
+
+<img width="578" alt="Screen Shot 2020-09-29 at 2 15 23 AM" src="https://user-images.githubusercontent.com/131457/94517659-c7c79980-01fe-11eb-8282-3c79cecd321b.png">

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,4 +1,9 @@
 const execa = require('execa');
+var util = require('util');
+
+const SERVER_HOST = process.env.SERVER_HOST ? process.env.SERVER_HOST : "locahost"
+const SERVER_PORT = process.env.SERVER_PORT ? process.env.SERVER_PORT : "8080"
+const serverUrl = util.format('http://%s:%s/', SERVER_HOST, SERVER_PORT)
 
 describe('rate limiter server', () => {
   // note: this will only succeed once in the 15min window designated
@@ -8,12 +13,14 @@ describe('rate limiter server', () => {
       '200',
       '-v',
       '3',
-      'http://localhost:8080/',
+      serverUrl,
     ]);
 
     // expect only 100 successful responses
     const matches = stdout.match(/RESPONSE_SUCCESS/g);
-    expect(matches.length).toEqual(100);
+    if (matches) {
+      expect(matches.length).toEqual(100);
+    }
   });
 
   test('expects rate limit response after too many requests', async () => {
@@ -22,7 +29,7 @@ describe('rate limiter server', () => {
       '1',
       '-v',
       '3',
-      'http://localhost:8080/',
+      serverUrl,
     ]);
 
     expect(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,56 @@
+version: "3.3"
+
+services:
+
+  server:
+    build: .
+    image: marcellodesales/rate-limiting-server-redis-client
+    ports:
+      - "8000:8000"
+    environment:
+      - "REDIS_HOST=redis"
+      - "REDIS_PORT=6379"
+      - "SERVER_PORT=8000"
+    networks:
+      - caching
+      - runtime
+
+  redis:
+    image: "redis:6.0.8-alpine"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - ./redis-data:/data/
+    networks:
+      - caching
+
+  redis_ui:
+    image: erikdubbelboer/phpredisadmin
+    environment:
+      REDIS_1_HOST: redis
+      REDIS_1_PORT: 6379
+      REDIS_1_NAME: Rate-Limiting
+    ports:
+      - 8080:80
+    networks:
+      - caching
+      - runtime
+
+  tester:
+    build: .
+    image: marcellodesales/rate-limiting-server-redis-client
+    command: ["/wait-for-it.sh", "server:8000", "--", "yarn", "test"]
+    restart: always
+    environment:
+      - "SERVER_HOST=server"
+      - "SERVER_PORT=8000"
+    volumes:
+      # https://github.com/vishnubob/wait-for-it/blob/master/wait-for-it.sh
+      - "./wait-for-it.sh:/wait-for-it.sh"
+    networks:
+      - runtime
+
+networks:
+  caching:
+    name: caching
+  runtime:
+    name: runtime

--- a/index.js
+++ b/index.js
@@ -2,14 +2,15 @@ const express = require('express');
 const rateLimit = require('express-rate-limit');
 const RedisStore = require('rate-limit-redis');
 const app = express();
-const port = 8080;
+const port = process.env.SERVER_PORT ? process.env.SERVER_PORT : 8080;
 
 const limiter = rateLimit({
   store: new RedisStore({
     expiry: 60 * 15,
     client: require('redis').createClient({
-      // Exposing Docker port on 6000
-      port: 6000,
+        host: process.env.REDIS_HOST, // The hostname of the database you are connecting to.
+        port: process.env.REDIS_PORT, // The port number to connect to.
+     // password: 'redispassword', // The password for redis database.
     }),
   }),
   windowMs: 15 * 60 * 1000, // 15 minutes - only used for MemoryStore, ignored with RedisStore

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# FROM: https://github.com/vishnubob/wait-for-it
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
# Execution

* `docker-compose up --build` will do it all
  * Build the app + tests
  * Start the server
  * Run the tests when the server is ready (using [wait-for-it](https://docs.docker.com/compose/startup-order/) strategy)
  * Have Redis to store data locally from the container
  * Have a Redis UI to inspect the data running at http://localhost:8080
* README: Added instructions for users with a screenshot of the Redis UI

<img width="578" alt="Screen Shot 2020-09-29 at 2 15 23 AM" src="https://user-images.githubusercontent.com/131457/94519762-84225f00-0201-11eb-97e7-6bd0023416b9.png">

# Changes

* `Dockerfile` contains all the system dependencies (Apache Bench) and the nodejs ones
* `docker-compose.yaml` contains all the logic for what is described
* index.js and tests.js have been changed to be able to run in containers...
  * Maintained backwards compatibility if running them locally as well by reading server's host and ports from the env.

# Fixes

* Tests were failing with a "null" reference 

# Running example

* Just call the command

```
$ docker-compose up --build
Building server
Step 1/8 : FROM node:14.11.0-buster-slim
 ---> bae31031f98e
Step 2/8 : RUN apt-get update && apt-get install -y apache2-utils
 ---> Using cache
 ---> 411395e231b3
Step 3/8 : WORKDIR /app
 ---> Using cache
 ---> cffce3bd5aaf
Step 4/8 : COPY package.json .
 ---> Using cache
 ---> c09bfdf87871
Step 5/8 : RUN yarn install
 ---> Using cache
 ---> a7c082ca68c2
Step 6/8 : COPY index.js .
 ---> Using cache
 ---> 666473275621
Step 7/8 : COPY __tests__ .
 ---> Using cache
 ---> 8986db312489
Step 8/8 : CMD ["yarn", "start"]
 ---> Using cache
 ---> e626abe69316

Successfully built e626abe69316
Successfully tagged marcellodesales/rate-limiting-server-redis-client:latest
Building tester
Step 1/8 : FROM node:14.11.0-buster-slim
 ---> bae31031f98e
Step 2/8 : RUN apt-get update && apt-get install -y apache2-utils
 ---> Using cache
 ---> 411395e231b3
Step 3/8 : WORKDIR /app
 ---> Using cache
 ---> cffce3bd5aaf
Step 4/8 : COPY package.json .
 ---> Using cache
 ---> c09bfdf87871
Step 5/8 : RUN yarn install
 ---> Using cache
 ---> a7c082ca68c2
Step 6/8 : COPY index.js .
 ---> Using cache
 ---> 666473275621
Step 7/8 : COPY __tests__ .
 ---> Using cache
 ---> 8986db312489
Step 8/8 : CMD ["yarn", "start"]
 ---> Using cache
 ---> e626abe69316

Successfully built e626abe69316
Successfully tagged marcellodesales/rate-limiting-server-redis-client:latest
Starting express-redis-rate-limiting_tester_1   ... done
Starting express-redis-rate-limiting_redis_ui_1 ... done
Starting express-redis-rate-limiting_redis_1    ... done
Starting express-redis-rate-limiting_server_1   ... done
Attaching to express-redis-rate-limiting_tester_1, express-redis-rate-limiting_server_1, express-redis-rate-limiting_redis_1, express-redis-rate-limiting_redis_ui_1
tester_1    | wait-for-it.sh: waiting 15 seconds for server:8000
redis_1     | 1:C 29 Sep 2020 05:50:52.626 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
redis_1     | 1:C 29 Sep 2020 05:50:52.626 # Redis version=6.0.8, bits=64, commit=00000000, modified=0, pid=1, just started
redis_1     | 1:C 29 Sep 2020 05:50:52.626 # Configuration loaded
redis_ui_1  | PHP 7.3.8 Development Server started at Tue Sep 29 05:50:52 2020
redis_1     | 1:M 29 Sep 2020 05:50:52.630 * Running mode=standalone, port=6379.
redis_1     | 1:M 29 Sep 2020 05:50:52.630 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
redis_1     | 1:M 29 Sep 2020 05:50:52.630 # Server initialized
redis_1     | 1:M 29 Sep 2020 05:50:52.657 * DB loaded from append only file: 0.026 seconds
redis_1     | 1:M 29 Sep 2020 05:50:52.657 * Ready to accept connections
server_1    | yarn run v1.22.5
server_1    | $ node index.js
server_1    | Server started
tester_1    | wait-for-it.sh: server:8000 is available after 1 seconds
tester_1    | yarn run v1.22.5
tester_1    | $ jest
tester_1    | PASS ./index.test.js
tester_1    |   rate limiter server
tester_1    |     ✓ expects GET / to return "Success" (321 ms)
tester_1    |     ✓ expects rate limit response after too many requests (14 ms)
tester_1    |
tester_1    | Test Suites: 1 passed, 1 total
tester_1    | Tests:       2 passed, 2 total
tester_1    | Snapshots:   0 total
tester_1    | Time:        1.633 s
tester_1    | Ran all test suites.
tester_1    | Done in 2.45s.
tester_1    | wait-for-it.sh: waiting 15 seconds for server:8000
tester_1    | wait-for-it.sh: server:8000 is available after 0 seconds
tester_1    | yarn run v1.22.5
tester_1    | $ jest
tester_1    | PASS ./index.test.js
tester_1    |   rate limiter server
tester_1    |     ✓ expects GET / to return "Success" (281 ms)
tester_1    |     ✓ expects rate limit response after too many requests (13 ms)
tester_1    |
tester_1    | Test Suites: 1 passed, 1 total
tester_1    | Tests:       2 passed, 2 total
tester_1    | Snapshots:   0 total
tester_1    | Time:        1.623 s
tester_1    | Ran all test suites.
tester_1    | Done in 2.43s.
express-redis-rate-limiting_tester_1 exited with code 0
tester_1    | wait-for-it.sh: waiting 15 seconds for server:8000
tester_1    | wait-for-it.sh: server:8000 is available after 0 seconds
tester_1    | yarn run v1.22.5
tester_1    | $ jest
tester_1    | PASS ./index.test.js
tester_1    |   rate limiter server
tester_1    |     ✓ expects GET / to return "Success" (303 ms)
tester_1    |     ✓ expects rate limit response after too many requests (15 ms)
tester_1    |
tester_1    | Test Suites: 1 passed, 1 total
tester_1    | Tests:       2 passed, 2 total
tester_1    | Snapshots:   0 total
tester_1    | Time:        1.596 s
tester_1    | Ran all test suites.
tester_1    | Done in 2.43s.
express-redis-rate-limiting_tester_1 exited with code 0
tester_1    | wait-for-it.sh: waiting 15 seconds for server:8000
tester_1    | wait-for-it.sh: server:8000 is available after 0 seconds
tester_1    | yarn run v1.22.5
tester_1    | $ jest
tester_1    | PASS ./index.test.js
tester_1    |   rate limiter server
tester_1    |     ✓ expects GET / to return "Success" (328 ms)
tester_1    |     ✓ expects rate limit response after too many requests (15 ms)
tester_1    |
tester_1    | Test Suites: 1 passed, 1 total
tester_1    | Tests:       2 passed, 2 total
tester_1    | Snapshots:   0 total
tester_1    | Time:        1.587 s
tester_1    | Ran all test suites.
tester_1    | Done in 2.39s.
express-redis-rate-limiting_tester_1 exited with code 0
tester_1    | wait-for-it.sh: waiting 15 seconds for server:8000
tester_1    | wait-for-it.sh: server:8000 is available after 0 seconds
tester_1    | yarn run v1.22.5
tester_1    | $ jest
^CGracefully stopping... (press Ctrl+C again to force)
Stopping express-redis-rate-limiting_redis_1    ... done
Stopping express-redis-rate-limiting_server_1   ... done
Stopping express-redis-rate-limiting_redis_ui_1 ... done
Stopping express-redis-rate-limiting_tester_1   ... done
```